### PR TITLE
cmd/web: fix installation instructions

### DIFF
--- a/cmd/web/tmpl/help.tmpl
+++ b/cmd/web/tmpl/help.tmpl
@@ -15,7 +15,7 @@
 
 <p>You can pipe commands or paste files to the pastebin using the command <code>tclip</code>. You can install it by installing the <a href="https://go.dev">Go</a> compiler toolkit and then running this command:</p>
 
-<pre><code>go get github.com/tailscale-dev/tclip/cmd/tclip@main</code></pre>
+<pre><code>go install github.com/tailscale-dev/tclip/cmd/tclip@main</code></pre>
 
 <p>Once it is installed, invoke it with the command <code>tclip</code>:</p>
 


### PR DESCRIPTION
`go get` is for updating go.mod, `go install` builds and installs the package.