### PR TITLE
Clarify how to authenticate service with Tailscale for local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ number of pastes.
 You can then test your changes to tclip by running `go run
 ./cmd/web` or `go run ./cmd/tclip` as appropriate.
 
+Note that for the first run of `./cmd/web`, you *must* set
+either the `TS_AUTHKEY` environment variable, or run it with
+`--tsnet-verbose` to get the login URL for Tailscale.
+
 ## Building for prod
 
 The web server:


### PR DESCRIPTION
I had some trouble getting this running locally and found that for local development of the webserver, either the `TS_AUTHKEY` variable had to be passed through or the authentication URL from the verbose tsnet output had to be used. I'm not sure if this is intentional or some misconfiguration on my end but it did work.