### PR TITLE
Treat org-mode as render-able document

### DIFF
--- a/cmd/web/tmpl/fancypost.html
+++ b/cmd/web/tmpl/fancypost.html
@@ -24,7 +24,11 @@
                     padding: 20px;
                     font-size: 0.875em;
                 }
-            }     
+            }
+
+			img {
+			  max-width: 100%;
+			}
         </style>
     </head>
     <body id="top">

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-enry/go-enry/v2 v2.8.4
 	github.com/google/uuid v1.3.1
 	github.com/microcosm-cc/bluemonday v1.0.25
+	github.com/niklasfasching/go-org v1.7.0
 	github.com/russross/blackfriday v1.6.0
 	modernc.org/sqlite v1.25.0
 	tailscale.com v1.48.2

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/niklasfasching/go-org v1.7.0 h1:vyMdcMWWTe/XmANk19F4k8XGBYg0GQ/gJGMimOjGMek=
+github.com/niklasfasching/go-org v1.7.0/go.mod h1:WuVm4d45oePiE0eX25GqTDQIt/qPW1T9DGkRscqLW5o=
 github.com/pierrec/lz4/v4 v4.1.14/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.17 h1:kV4Ip+/hUBC+8T6+2EgburRtkE9ef4nbY3f4dFhGjMc=
 github.com/pierrec/lz4/v4 v4.1.17/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -58,12 +58,12 @@ schema = 3
   [mod."github.com/coreos/go-iptables"]
     version = "v0.6.0"
     hash = "sha256-hB+9XsybJuEFozAXo+G8+2qMMZGoqBbMmSwmcNJgmSU="
-  [mod."github.com/dustin/go-humanize"]
-    version = "v1.0.1"
-    hash = "sha256-yuvxYYngpfVkUg9yAmG99IUVmADTQA0tMbBXe0Fq0Mc="
   [mod."github.com/dblohm7/wingoes"]
     version = "v0.0.0-20230803162905-5c6286bb8c6e"
     hash = "sha256-YPZP7Hq96I9+3gHyLp0sTsk0IN2wWSJXGHh+kJNRgAk="
+  [mod."github.com/dustin/go-humanize"]
+    version = "v1.0.1"
+    hash = "sha256-yuvxYYngpfVkUg9yAmG99IUVmADTQA0tMbBXe0Fq0Mc="
   [mod."github.com/fxamacker/cbor/v2"]
     version = "v2.4.0"
     hash = "sha256-LwOrfDN5fx/R2lgaD90RIu2NxcJDpyqYEURLc9Kgxgw="
@@ -113,8 +113,8 @@ schema = 3
     version = "v1.1.1-0.20230202152459-5c7d0dd6ab86"
     hash = "sha256-dgyrLXuM55z8FAoUjyt5TDlzim6HfphWo5wx1/DHLwE="
   [mod."github.com/jsimonetti/rtnetlink"]
-    version = "v1.1.2-0.20220408201609-d380b505068b"
-    hash = "sha256-xHfsLwbycxNNyFI9zTfSMsb2T35BKEWyW6Fmk1tDWM4="
+    version = "v1.3.2"
+    hash = "sha256-clvnQA5M4NHgv03tGDmdFmcfSjoqeZC3Gfy30rtFECI="
   [mod."github.com/kballard/go-shellquote"]
     version = "v0.0.0-20180428030007-95032a82bc51"
     hash = "sha256-AOEdKETBMUC39ln6jBJ9NYdJWp++jV5lSbjNqG3dV+c="
@@ -125,8 +125,8 @@ schema = 3
     version = "v0.0.0-20200729010619-da482cc4850a"
     hash = "sha256-lnr9r/KNv4EeeNohFImC3Vd5E9nJ0N+4ZZ0VHFjwHps="
   [mod."github.com/mattn/go-isatty"]
-    version = "v0.0.16"
-    hash = "sha256-YMaPZvShDfA98vqw1+zWWl7M1IT4nHPGBrAt7kHo8Iw="
+    version = "v0.0.18"
+    hash = "sha256-QpIn0DSggtBn2ocyj0RlXDKLK5F5KZG1/ogzrqBCjF8="
   [mod."github.com/mdlayher/genetlink"]
     version = "v1.3.2"
     hash = "sha256-pgwXkyDY1dlB8tmV1lQ0Bz/2g0zmJOyXvQjacACy924="
@@ -148,6 +148,9 @@ schema = 3
   [mod."github.com/mitchellh/go-ps"]
     version = "v1.0.0"
     hash = "sha256-HzxVHNLHZpnsBuPcub0G+9jjDcDOsxM/6wifbsxf7EY="
+  [mod."github.com/niklasfasching/go-org"]
+    version = "v1.7.0"
+    hash = "sha256-i3NdcfER5JSIJv3GIJxeNJJpOyxiyxQKPZPpK2teQt4="
   [mod."github.com/pierrec/lz4/v4"]
     version = "v4.1.17"
     hash = "sha256-36L+GNhRrHBCyhbHCqweCk5rfmggdRtHqH6g5m1ViQI="


### PR DESCRIPTION
I quite like writing my blog posts and other content using org-mode, and being able to present it in the same way one would with a Markdown document is (I believe) important for a paste service. This leverages https://github.com/niklasfasching/go-org, which is the same library Hugo utilises under the hood for its own org-mode rendering. I've tried my best to match it to the Markdown rendering, but some things do differ slightly, like org-mode exporting with a table of contents by default.