### PR TITLE
fix: remove markdown hack

### DIFF
--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -504,11 +504,6 @@ WHERE p.id = ?1`
 
 	var rawHTML *template.HTML
 
-	// XXX(Xe): HACK around https://github.com/go-enry/go-enry/pull/154
-	if filepath.Ext(fname) == ".markdown" {
-		lang = "Markdown"
-	}
-
 	var cssClass string
 	if lang != "" {
 		cssClass = fmt.Sprintf("lang-%s", strings.ToLower(lang))


### PR DESCRIPTION
~~`GetLanguageByFilename` appears to be for specially named files https://github.com/go-enry/go-enry/blob/master/data/filename.go~~

~~`GetLanguageByExtension` is (imo) the most likely way to match files, followed by special file names, and finally by content.~~

`GetLanguage` is likely the best general strategy, as seen in #26. 
This PR can most likely be closed as superseded, unless you'd like to use this PR as a more contained "enry update".

This also resolves the hack in place, as `.markdown` is already supported by enry.
https://github.com/go-enry/go-enry/blob/93616cf55babb3e8d3b5ee143033c53511c7ce88/data/extension.go#L625