### PR TITLE
Add one-click deploy button (on Railway) to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,24 +14,27 @@ number of pastes.
 You can then test your changes to tclip by running `go run
 ./cmd/web` or `go run ./cmd/tclip` as appropriate.
 
-Note that for the first run of `./cmd/web`, you *must* set
+Note that for the first run of `./cmd/web`, you _must_ set
 either the `TS_AUTHKEY` environment variable, or run it with
 `--tsnet-verbose` to get the login URL for Tailscale.
 
 ## Building for prod
 
 The web server:
+
 ```
 nix build .#web
 ```
 
 The docker image:
+
 ```
 nix build .#docker
 docker load < ./result
 ```
 
 The portable service image:
+
 ```
 nix build .#portable-service
 ```
@@ -95,6 +98,12 @@ paste to your heart's content.
 #### Updating
 
 Run `flyctl deploy` to update the service.
+
+### Railway
+
+One-click deploy from a pre-configured [Railway](https://railway.app) template:
+
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/HzYDtl?referralCode=mg)
 
 ### Normal Docker
 


### PR DESCRIPTION
Gives users an additional method of deploying tclip, and arguably, an easier one than many other methods. Template is pre-configured with a disk & correct mount paths, simply need to copy+paste value for `TS_AUTHKEY` and should be good to go.

Also note: Railway has a kick-back program and this link technically has my referral code in it. Opened this PR not for this reason (don't expect any kickback whatsoever nor do I care about this), but because I legitimately think Railway is the most convenient way to deploy stuff like this :)