### PR TITLE
cmd/tclipd: allow creating tokens to edit the contents of a note from a Internet node

### DIFF
--- a/cmd/tclipd/schema.sql
+++ b/cmd/tclipd/schema.sql
@@ -18,3 +18,12 @@ CREATE TABLE IF NOT EXISTS users
   , display_name TEXT NOT NULL
   , profile_pic_url TEXT NOT NULL
   );
+
+-- Tokens that allow an anonymous user to set a paste
+CREATE TABLE IF NOT EXISTS paste_tokens
+    ( id TEXT PRIMARY KEY NOT NULL
+    , token TEXT NOT NULL UNIQUE
+    , paste_id TEXT NOT NULL
+    , description TEXT NOT NULL
+    , FOREIGN KEY (paste_id) REFERENCES pastes(id)
+    );

--- a/cmd/tclipd/tmpl/showpaste.html
+++ b/cmd/tclipd/tmpl/showpaste.html
@@ -26,4 +26,25 @@
 
 <a class="my-4 font-semibold underline text-gray-900 hover:text-gray-500" href="/paste/{{.ID}}">Permalink</a> - <a class="font-semibold underline text-gray-900 hover:text-gray-500" href="/paste/{{.ID}}/dl">Download</a> - <a class="font-semibold underline text-gray-900 hover:text-gray-500" href="/paste/{{.ID}}/raw">Raw</a>{{if .RawHTML}} - <a class="font-semibold underline text-gray-900 hover:text-gray-500" href="/paste/{{.ID}}/md">Fancy</a>{{end}}{{if eq .UserID .PasterUserID}} - <a class="font-semibold underline text-gray-900 hover:text-gray-500" href="/api/delete/{{.ID}}">Delete</a>{{end}}
 
+{{ if eq .UserID .PasterUserID }}
+    {{ if .Tokens }}
+        {{$ID := .ID}}
+        <h2 class="my-4 text-xl font-bold pb-2">Tokens to edit this note</h1>
+        <ul>
+            {{ range $k, $v := .Tokens }}
+            <li class="relative w-full">
+                <span>{{$v}}</span>
+                <a class="font-semibold underline text-gray-900 hover:text-gray-500" href="/api/token/delete/{{$k}}?goback=1">Delete</a>
+            </li>
+            {{ end }}
+        </ul>
+    {{ end }}
+    <h2 class="my-4 text-xl font-bold pb-2">Create new token</h1>
+    <form action="/api/token/add/{{.ID}}">
+        <label for="description">Description: </label>
+        <input class="m-0" type="text" name="description"><br>
+        <button type="submit" class="font-semibold underline text-gray-900 hover:text-gray-500">Create new token</button>
+    </form>
+{{ end }}
+
 {{template "footer" .}}


### PR DESCRIPTION
This is a opt-in feature that, to be enabled, one must pass a flag (`-use-set-tokens`) or a environment variable (`USE_SET_TOKENS`) to enable.

Basically it allows the owner of a note to create edit tokens. The flow is the following:
- User creates a note.
- User creates a token for a note.
- Server gives a full URL.
- User can now set the content of that note by passing the content as body to the full URL of the previous step.
- If funnel is enabled then the user can even use the tokens through the Internet using any machine that speaks HTTP and can connect to the Internet.

In practice:
- `go run -v ./cmd/tclipd  -data-location /tmp/test-paste -hostname test-paste -tsnet-verbose -use-funnel -use-set-tokens`
- Create a note from the Web UI then a token on the note page
- It will give you a full link like `https://test-paste.stargazer-shark.ts.net/api/token/set/0d4f1364-548f-4fdd-ba08-d5e1c3503044`
- Change the content of the note using HTTP requests
  - Ex: `curl https://test-paste.stargazer-shark.ts.net/api/token/set/0d4f1364-548f-4fdd-ba08-d5e1c3503044 -d blah`

I also abstracted away some details like the function to assert that the request is in the form format to a function to reuse in other routes (before that this logic was only used once).

BTW I hope I got the CSS right lol.