### PR TITLE
*: fix forgotten renames from web to tclipd

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ number of pastes.
 3. `nix develop`
 
 You can then test your changes to tclip by running `go run
-./cmd/web` or `go run ./cmd/tclip` as appropriate.
+./cmd/tclipd` or `go run ./cmd/tclip` as appropriate.
 
-Note that for the first run of `./cmd/web`, you *must* set
+Note that for the first run of `./cmd/tclipd`, you *must* set
 either the `TS_AUTHKEY` environment variable, or run it with
 `--tsnet-verbose` to get the login URL for Tailscale.
 
@@ -22,7 +22,7 @@ either the `TS_AUTHKEY` environment variable, or run it with
 
 The web server:
 ```
-nix build .#web
+nix build .#tclipd
 ```
 
 The docker image:

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "description": "tclip, the pastebin for tailscale",
   "scripts": {
-    "start:css": "tailwindcss --watch -o cmd/web/static/css/base.css",
-    "build:css": "tailwindcss -o cmd/web/static/css/base.css"
+    "start:css": "tailwindcss --watch -o cmd/tclipd/static/css/base.css",
+    "build:css": "tailwindcss -o cmd/tclipd/static/css/base.css"
   },
   "dependencies": {
     "@tailwindcss/forms": "^0.5.4",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    content: ["./cmd/web/tmpl/*.html"],
+    content: ["./cmd/tclipd/tmpl/*.html"],
     theme: {
       colors: {
         blue: {


### PR DESCRIPTION
In a previous commit, `web` folder is renamed to `tclipd` but there were some references that were missed.