### PR TITLE
fix: set default language for Prism to `text`

### DIFF
--- a/cmd/tclipd/main.go
+++ b/cmd/tclipd/main.go
@@ -532,7 +532,7 @@ WHERE p.id = ?1`
 
 	var rawHTML *template.HTML
 
-	var cssClass string
+	cssClass := "language-text"
 	if lang != "" {
 		cssClass = fmt.Sprintf("lang-%s", strings.ToLower(lang))
 	}


### PR DESCRIPTION
Set a default value for `cssClass` so that pastes without an extension in their filename won't look really weird, compared to everything else.