### PR TITLE
Fix dark theme

### DIFF
--- a/cmd/tclipd/tmpl/showpaste.html
+++ b/cmd/tclipd/tmpl/showpaste.html
@@ -39,7 +39,7 @@
 <p class="dark:text-gray-300">Created at {{.CreatedAt}}</p>
 
 {{if .RawHTML}}
-<article class="my-6 prose">{{.RawHTML}}</article>
+<article class="my-6 prose dark:prose-invert">{{.RawHTML}}</article>
 {{else}}
 <div class="inline-block w-full">
 	<pre


### PR DESCRIPTION
When viewing Markdown pastes on dark theme, text is shown in a dark font against a dark background.
![image](https://github.com/user-attachments/assets/06b0598b-765b-47b6-a8c7-01fdbfe34786)

Fixed by adding `dark:prose-invert` to the css class list