### PR TITLE
cmd/tclipd: disable HTTPS and warn if enabled but unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ environment variables. All of them are optional.
 | `-hide-funnel-users`    | `HIDE_FUNNEL_USERS`    | `false`                     | If set, don't display the username and profile picture of the user who created the paste in funneled pastes. |
 | `-http-port`            | `HTTP_PORT`            | unset                       | If set, expose individual pastes on a HTTP server running on the given port.                                 |
 | `-control-url`          | `TSNET_CONTROL_URL`    | unset                       | If set, a custom control server to use, e.g. for Headscale users.                                            |
-| `-disable-https`        | `DISABLE_HTTPS`        | `false`                     | If set, disable serving on HTTPS with Serve. Useful for Headscale deployments.                               |
+| `-disable-https`        | `DISABLE_HTTPS`        | `false`, becomes `true` when HTTPS is unavailable on the tailnet.                     | If set, disable serving on HTTPS, even if HTTPS serving is available.                               |
 | `-enable-line-numbers`  | `ENABLE_LINE_NUMBERS`  | `false`                     | If set, enable line numbers being shown when viewing a paste.                                                |
 | `-enable-word-wrap`     | `ENABLE_WORD_WRAP`     | `false`                     | If set, allows lines to break and wrap to the following line.                                                |
 

--- a/cmd/tclipd/main.go
+++ b/cmd/tclipd/main.go
@@ -737,12 +737,13 @@ func main() {
 	ctx := context.Background()
 	tclipURL, ok := lc.ExpandSNIName(ctx, *hostname)
 	if !ok {
+		log.Println("warning: HTTPS is unavailable, please check that it is enabled in the admin panel and that the hostname is configured correctly. Proceeding with only HTTP.")
+		*disableHTTPS = true
+	}
+
+	// if the user disabled HTTPS or HTTPS is unavailable
 		if *disableHTTPS {
 			tclipURL = *hostname
-		} else {
-			log.Println(tclipURL)
-			log.Fatal("HTTPS is not enabled in the admin panel")
-		}
 	}
 
 	ln, err := s.Listen("tcp", ":80")


### PR DESCRIPTION
If disable-https is not set but HTTPS support is unconfigured or broken, warn the user and fall through to HTTP-only.

Removes the requirement to set disable-https for Headscale deployments.