### PR TITLE
cmd/tclipd: defer the prism script

### DIFF
--- a/cmd/tclipd/tmpl/fancypost.html
+++ b/cmd/tclipd/tmpl/fancypost.html
@@ -34,7 +34,7 @@
 </head>
 
 <body id="top">
-    <script src="/static/js/prism.js"></script>
+    <script defer src="/static/js/prism.js"></script>
     <main>
         <article>
             {{.RawHTML}}

--- a/cmd/tclipd/tmpl/showpaste.html
+++ b/cmd/tclipd/tmpl/showpaste.html
@@ -14,7 +14,7 @@
 	}
 </style>
 
-<script src="/static/js/prism.js"></script>
+<script defer src="/static/js/prism.js"></script>
 
 {{if .UserInfo}}
 {{if ne .PasterUserID .UserID}}

--- a/cmd/tclipd/tmpl/showpaste.html
+++ b/cmd/tclipd/tmpl/showpaste.html
@@ -43,7 +43,7 @@
 {{else}}
 <div class="inline-block w-full">
 	<pre
-		class="{{.EnableLineNumbers}} {{.EnableWordWrap}}"><code class="my-6 max-w-full {{.CSSClass}}">{{.Data}}</code></pre>
+		class="{{.EnableLineNumbers}} {{.EnableWordWrap}} language-text"><code class="my-6 max-w-full {{.CSSClass}}">{{.Data}}</code></pre>
 </div>
 <br />
 {{end}}


### PR DESCRIPTION
Since the `prism.js` script is 579KB, loading an individual paste means the user has to wait for the blocking script to fully finish loading before they can view the paste contents.

This PR defers the script so that the paste can load first, and the Prism highlighter can kick in afterwards.

I also added in a neat little optimization hack: I forced in a `language-text` class so paste contents have a proper codeblock and don't bleed into the background. The Prism script then removes this class and adds in a proper one depending on the language when it finishes loading.